### PR TITLE
Patch for Vanilla Furniture Expanded, based on VanillaExpanded-RoyaltyPatches.

### DIFF
--- a/1.4/Patches/VFE.xml
+++ b/1.4/Patches/VFE.xml
@@ -6,22 +6,50 @@
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
+        <!-- EndTable :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if it's -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="EndTable"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="EndTable"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOf">
+                <things>
+                  <li>EndTable</li>
+                </things>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Dresser :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="dVFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="Dresser"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="Dresser"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOf">
+                <things>
+                  <li>Dresser</li>
+                </things>
+              </li>
+            </value>
+          </match>
+        </li>
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
           <value>
             <li>Bed_Kingsize</li>
             <li>Bed_DoubleErgonomic</li>
           </value>
         </li>
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
           <value>
             <li>Table_LightEndTable</li>
             <li>Table_RoyalEndTable</li>
           </value>
         </li>
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
           <value>
             <li>Table_RoyalDresser</li>
           </value>
@@ -33,7 +61,7 @@
           <match Class="PatchOperationSequence">
             <operations>
               <li Class="PatchOperationAdd">
-                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
                 <value>
                   <li>Table_DarkLightEndTable</li>
                 </value>

--- a/1.4/Patches/VFE.xml
+++ b/1.4/Patches/VFE.xml
@@ -22,7 +22,7 @@
         </li>
         <!-- Dresser :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf -->
         <li Class="PatchOperationConditional">
-          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="dVFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="Dresser"]</xpath>
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="Dresser"]</xpath>
           <match Class="PatchOperationReplace">
             <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="Dresser"]</xpath>
             <value>

--- a/1.4/Patches/VFE.xml
+++ b/1.4/Patches/VFE.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Furniture Expanded</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
+          <value>
+            <li>Bed_Kingsize</li>
+            <li>Bed_DoubleErgonomic</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+          <value>
+            <li>Table_LightEndTable</li>
+            <li>Table_RoyalEndTable</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
+          <value>
+            <li>Table_RoyalDresser</li>
+          </value>
+        </li>
+        <li Class="PatchOperationFindMod">
+          <mods>
+            <li>Vanilla Expanded - Ideology Patches</li>
+          </mods>
+          <match Class="PatchOperationSequence">
+            <operations>
+              <li Class="PatchOperationAdd">
+                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+                <value>
+                  <li>Table_DarkLightEndTable</li>
+                </value>
+              </li>
+            </operations>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/1.4/Patches/VFE_Art.xml
+++ b/1.4/Patches/VFE_Art.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+  <!-- Royalty need patches-->
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Furniture Expanded - Art</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RoyalTitleDef[defName=defName="Knight" or defName="Praetor" or defName="Baron" or defName="Count" or @Name="BaseEmpireTitleNPC"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Column"]/things</xpath>
+          <value>
+            <li>VFE_Pillar</li>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/1.4/Patches/VFE_Art.xml
+++ b/1.4/Patches/VFE_Art.xml
@@ -7,8 +7,113 @@
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
+        <!-- Columns :: Archcount :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required-->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>8</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Marquess :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Marquess"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Marquess"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>10</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Duke :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="Duke"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="Duke"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>12</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: ArchDuke or Consul :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archduke" or defName = "Consul"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archduke" or defName = "Consul"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>14</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Magister :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Magister"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Magister"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>16</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Despot :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Despot"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Despot"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>18</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Stellarch High Stellarch :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="Stellarch" or defName = "VFEE_HighStellarch"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="Stellarch" or defName = "VFEE_HighStellarch"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>24</count>
+              </li>
+            </value>
+          </match>
+        </li>
         <li Class="PatchOperationAdd">
-          <xpath>Defs/RoyalTitleDef[defName=defName="Knight" or defName="Praetor" or defName="Baron" or defName="Count" or @Name="BaseEmpireTitleNPC"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Column"]/things</xpath>
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Column"]/things</xpath>
           <value>
             <li>VFE_Pillar</li>
           </value>

--- a/1.4/Patches/VFE_Spacer.xml
+++ b/1.4/Patches/VFE_Spacer.xml
@@ -7,20 +7,48 @@
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
+        <!-- EndTable :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if it's -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="EndTable"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="EndTable"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOf">
+                <things>
+                  <li>EndTable</li>
+                </things>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Dresser :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="Dresser"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements//li[@Class="RoomRequirement_Thing"][thingDef="Dresser"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOf">
+                <things>
+                  <li>Dresser</li>
+                </things>
+              </li>
+            </value>
+          </match>
+        </li>
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
           <value>
             <li>Bed_AdvDoubleBed</li>
           </value>
         </li>
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
           <value>
             <li>Table_IlluminatedEndTable</li>
           </value>
         </li>
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
           <value>
             <li>Table_IlluminatedDresser</li>
           </value>
@@ -33,13 +61,13 @@
           <match Class="PatchOperationSequence">
             <operations>
               <li Class="PatchOperationAdd">
-                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
                 <value>
                   <li>Table_DarkIlluminatedEndTable</li>
                 </value>
               </li>
               <li Class="PatchOperationAdd">
-                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
+                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
                 <value>
                   <li>Table_DarkIlluminatedDresser</li>
                 </value>

--- a/1.4/Patches/VFE_Spacer.xml
+++ b/1.4/Patches/VFE_Spacer.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+  <!-- Royalty need patches-->
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Furniture Expanded - Spacer Module</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
+          <value>
+            <li>Bed_AdvDoubleBed</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+          <value>
+            <li>Table_IlluminatedEndTable</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
+          <value>
+            <li>Table_IlluminatedDresser</li>
+          </value>
+        </li>
+        <!-- This was commented out in VanillaExpanded-RoyaltyPatches. Cargo Cult it here just in case. -->
+        <!-- <li Class="PatchOperationFindMod">
+          <mods>
+            <li>Vanilla Expanded - Ideology Patches</li>
+          </mods>
+          <match Class="PatchOperationSequence">
+            <operations>
+              <li Class="PatchOperationAdd">
+                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="EndTable"]/things</xpath>
+                <value>
+                  <li>Table_DarkIlluminatedEndTable</li>
+                </value>
+              </li>
+              <li Class="PatchOperationAdd">
+                <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][things/li="Dresser"]/things</xpath>
+                <value>
+                  <li>Table_DarkIlluminatedDresser</li>
+                </value>
+              </li>
+            </operations>
+          </match>
+        </li> -->
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/1.4/Patches/VFE_Vikings.xml
+++ b/1.4/Patches/VFE_Vikings.xml
@@ -1,0 +1,44 @@
+<Patch>
+  <!-- Royalty need patches-->
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Vikings</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Column"]/things</xpath>
+          <value>
+            <li>VFEV_RunedColumn</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Brazier"]/things</xpath>
+          <value>
+            <li>VFEV_Hearth</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_AllThingsAnyOfAreGlowing"][labelKey="RoomRequirementAllBraziersMustBeLit"]/things</xpath>
+          <value>
+            <li>VFEV_Hearth</li>
+          </value>
+        </li>
+  </Operation>
+  <!-- Toggable -->
+  <Operation Class="VFECore.PatchOperationToggableSequence">
+    <enabled>False</enabled>
+    <label>Allow royals to use double fur bed:</label>
+    <mods>
+      <li>Vanilla Factions Expanded - Vikings</li>
+    </mods>
+    <operations>
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
+        <value>
+          <li>VFEV_DoubleFurBed</li>
+        </value>
+      </li>
+    </operations>
+  </Operation>
+</Patch>

--- a/1.4/Patches/VFE_Vikings.xml
+++ b/1.4/Patches/VFE_Vikings.xml
@@ -6,24 +6,131 @@
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
+      <!-- Columns :: Archcount :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required-->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>8</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Marquess :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Marquess"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Marquess"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>10</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Duke :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="Duke"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="Duke"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>12</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: ArchDuke or Consul :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archduke" or defName = "Consul"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Archduke" or defName = "Consul"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>14</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Magister :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Magister"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Magister"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>16</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Despot :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Despot"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="VFEE_Despot"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>18</count>
+              </li>
+            </value>
+          </match>
+        </li>
+        <!-- Columns :: Stellarch High Stellarch :: Replace the RoomRequirement_Thing with RoomRequirement_ThingAnyOf if required -->
+        <li Class="PatchOperationConditional">
+          <xpath>Defs/RoyalTitleDef[defName="Stellarch" or defName = "VFEE_HighStellarch"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+          <match Class="PatchOperationReplace">
+            <xpath>Defs/RoyalTitleDef[defName="Stellarch" or defName = "VFEE_HighStellarch"]/throneRoomRequirements//li[@Class="RoomRequirement_ThingCount"][thingDef="Column"]</xpath>
+            <value>
+              <li Class="RoomRequirement_ThingAnyOfCount">
+                <things>
+                  <li>Column</li>
+                </things>
+                <count>24</count>
+              </li>
+            </value>
+          </match>
+        </li>
         <li Class="PatchOperationAdd">
-          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Column"]/things</xpath>
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Column"]/things</xpath>
           <value>
             <li>VFEV_RunedColumn</li>
           </value>
         </li>
         <li Class="PatchOperationAdd">
-          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Brazier"]/things</xpath>
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_ThingAnyOfCount"][things/li="Brazier"]/things</xpath>
           <value>
             <li>VFEV_Hearth</li>
           </value>
         </li>
         <li Class="PatchOperationAdd">
-          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_AllThingsAnyOfAreGlowing"][labelKey="RoomRequirementAllBraziersMustBeLit"]/things</xpath>
+          <xpath>Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/throneRoomRequirements/li[@Class="RoomRequirement_AllThingsAnyOfAreGlowing"][labelKey="RoomRequirementAllBraziersMustBeLit"]/things</xpath>
           <value>
             <li>VFEV_Hearth</li>
           </value>
         </li>
+      </operations>
+    </match>
   </Operation>
   <!-- Toggable -->
   <Operation Class="VFECore.PatchOperationToggableSequence">
@@ -34,7 +141,7 @@
     </mods>
     <operations>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName="VFEE_Archduke" or defName="VFEE_Magister" or defName="VFEE_Despot" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
+        <xpath>/Defs/RoyalTitleDef[defName="VFEE_Archcount" or defName="VFEE_Marquess" or defName = "Duke" or defName="VFEE_Archduke" or defName = "Consul" or defName="VFEE_Magister" or defName="VFEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]FEE_Despot" or defName = "Stellarch" or @Name="VFEE_HighStellarch"]/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"][disablingPrecepts/li="SlabBed_Preferred"]/things</xpath>
         <value>
           <li>VFEV_DoubleFurBed</li>
         </value>


### PR DESCRIPTION
- Copies over VFE patches from [VanillaExpanded-RoyaltyPatches](https://github.com/Vanilla-Expanded/VanillaExpanded-RoyaltyPatches), but with the defNames modified to match the new titles added by this mod.
- Rather than changingthe definitions of the new title roles for all users, these patches will switch to use ThingAnyOf only if a VFE mod that extends the list is included.