### PR TITLE
Added a null map check for quest nodes using maps

### DIFF
--- a/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/QuestNode_DelayedRitualReward.cs
+++ b/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/QuestNode_DelayedRitualReward.cs
@@ -36,7 +36,7 @@ namespace VFEEmpire
         }
         protected override bool TestRunInt(Slate slate)
         {
-            return slate.Get<Pawn>("rewardGiver", null, false) != null && slate.TryGet<FloatRange>("marketValueRange", out var floatRange, false);
+            return QuestGen_Get.GetMap() != null && slate.Get<Pawn>("rewardGiver", null, false) != null && slate.TryGet<FloatRange>("marketValueRange", out var floatRange, false);
         }
     }
 }

--- a/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/QuestNode_DeserterHideout.cs
+++ b/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/QuestNode_DeserterHideout.cs
@@ -193,10 +193,11 @@ namespace VFEEmpire
         }
         protected override bool TestRunInt(Slate slate)
         {
+            var map = QuestGen_Get.GetMap();
+            if (map == null) return false;
             var points = slate.Get<float>("points",0f);
             points = pointAdjust.Evaluate(points);
             var deserter = Find.FactionManager.FirstFactionOfDef(InternalDefOf.VFEE_Deserters);
-            var map = QuestGen_Get.GetMap();
             int pawnCount = GetRequiredPawnCount(map.mapPawns.FreeColonists.Count, points);
             return pawnCount != -1 && TileFinder.TryFindNewSiteTile(out var tile) && deserter != null && deserter.HostileTo(Faction.OfPlayer); 
         }

--- a/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/Questnode_Root_ArtExhibit.cs
+++ b/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/Questnode_Root_ArtExhibit.cs
@@ -15,6 +15,7 @@ namespace VFEEmpire
         protected override bool TestRunInt(Slate slate)
         {
             Map map = QuestGen_Get.GetMap(false, null);
+            if (map == null) return false;
 
             bool title = map.mapPawns.FreeColonistsSpawned.Select(x => x.royalty.MostSeniorTitle).Any(x => x?.def.Ext() != null && !x.def.Ext().galleryRequirements.NullOrEmpty());
             return title && !Faction.OfEmpire.HostileTo(Faction.OfPlayer) && map.RoyaltyTracker().Galleries.Any(); 

--- a/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/Questnode_Root_GrandBall.cs
+++ b/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/Questnode_Root_GrandBall.cs
@@ -15,6 +15,7 @@ namespace VFEEmpire
         protected override bool TestRunInt(Slate slate)
         {
             Map map = QuestGen_Get.GetMap(false, null);
+            if (map == null) return false;
             bool title = map.mapPawns.FreeColonistsSpawned.Select(x => x.royalty.MostSeniorTitle).Any(x => x?.def.Ext() != null && !x.def.Ext().ballroomRequirements.NullOrEmpty());
             return title && !Faction.OfEmpire.HostileTo(Faction.OfPlayer) && map.RoyaltyTracker().Ballrooms.Any(); 
         }

--- a/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/Questnode_Root_NobleVisit.cs
+++ b/1.4/Source/VFEEmpire/VFEEmpire/QuestNode/Questnode_Root_NobleVisit.cs
@@ -27,7 +27,7 @@ public class QuestNode_Root_NobleVisit : QuestNode
     protected override bool TestRunInt(Slate slate)
     {
         var map = QuestGen_Get.GetMap();
-        return map.mapPawns.FreeColonistsSpawned.Select(x => x.royalty.MostSeniorTitle).Any(x => x != null) && !Faction.OfPlayer.HostileTo(Faction.OfEmpire);
+        return map != null && map.mapPawns.FreeColonistsSpawned.Select(x => x.royalty.MostSeniorTitle).Any(x => x != null) && !Faction.OfPlayer.HostileTo(Faction.OfEmpire);
     }
 
     protected override void RunInt()


### PR DESCRIPTION
If I'm understanding this correctly, there should never be a null map when `TestRunInt` or `RunInt` for those specific quest nodes.

However, I somehow managed to achieve a situation where the map is null when running `TestRunInt`, causing a `NullReferenceException` - specifically, any time (even an unrelated) quest was generated each of those quest nodes would throw that specific exception (besides DelayedRitualReward, as it doesn't operate on the map in `TestRunInt` - it only uses it in `RunInt`). It was a heavily modded game, and I was not able to reproduce it a second time - only happening on 1 saved game.

So as I've just explained - it's extremely unlikely that the null map check will be useful for big majority of the players... However, this should provide some extra safety in case something goes really bad, as it happened to me.