### PR TITLE
Improvements to honor generation

### DIFF
--- a/1.5/Source/VFEEmpire/VFEEmpire/Utilities/HonorUtility.cs
+++ b/1.5/Source/VFEEmpire/VFEEmpire/Utilities/HonorUtility.cs
@@ -55,9 +55,12 @@ public static class HonorUtility
         if (DefDatabase<HonorDef>.AllDefs.Where(def => def.Worker.Available() && def.value <= pointsLocal).TryRandomElement(out var def))
         {
             var honor = def.Worker.Generate();
-            honor.PostMake();
-            points -= def.value;
-            return honor;
+            if (honor != null)
+            {
+                honor.PostMake();
+                points -= def.value;
+                return honor;
+            }
         }
 
         return null;
@@ -96,6 +99,10 @@ public static class HonorUtility
     public static void GrantRandomHonor(Pawn pawn)
     {
         var points = 1000f;
-        pawn.AddHonor(Generate(ref points));
+        var honor = Generate(ref points);
+        if (honor != null)
+            pawn.AddHonor(honor);
+        else
+            Log.Error($"Failed to generate a random honor with {points} points.");
     }
 }

--- a/1.5/Source/VFEEmpire/VFEEmpire/Workers/HonorWorker_Faction.cs
+++ b/1.5/Source/VFEEmpire/VFEEmpire/Workers/HonorWorker_Faction.cs
@@ -10,7 +10,12 @@ public class HonorWorker_Faction : HonorWorker
     public override Honor Generate()
     {
         var honor = base.Generate();
-        if (honor is Honor_Faction honorFaction) honorFaction.faction = GetFaction();
+        if (honor is Honor_Faction honorFaction)
+        {
+            honorFaction.faction = GetFaction();
+            if (honorFaction.faction == null)
+                return null;
+        }
         return honor;
     }
 
@@ -19,11 +24,16 @@ public class HonorWorker_Faction : HonorWorker
     private Faction GetFaction() => Find.FactionManager.AllFactionsListForReading.Where(FactionValid).RandomElementWithFallback();
 
     protected virtual bool FactionValid(Faction f) =>
-        def.hostileFactions
+        !f.temporary &&
+        !f.def.hidden &&
+        f.def.humanlikeFaction &&
+        !f.IsPlayer &&
+        // Parenthesis required
+        (def.hostileFactions
             ? f.HostileTo(Faction.OfPlayer)
             : !f.HostileTo(Faction.OfPlayer) && HonorUtility.All()
                .OfType<Honor_Faction>()
-               .All(h => h.def != def || h.faction != f);
+               .All(h => h.def != def || h.faction != f));
 }
 
 public class Honor_Faction : Honor


### PR DESCRIPTION
- Honors targeting a specific faction can no longer target:
  - The player faction
  - Temporary factions
  - Non-humanlike factions
  - Hidden faction
- Honors targeting a specific faction can no longer generate with no target faction
  - This most likely could only happen if a game doesn't have enough factions in the game to generate them for, as the honors can only generate 1 honor of each def
- Improved handling of situations where an honor could not generate properly (no more possible honors to generate), so they should not cause errors