### PR TITLE
Add a minimum tithe amount of 1

### DIFF
--- a/1.5/Source/VFEEmpire/VFEEmpire/TitheTypeDef.cs
+++ b/1.5/Source/VFEEmpire/VFEEmpire/TitheTypeDef.cs
@@ -33,11 +33,11 @@ public class TitheTypeDef : Def
 public class TitheWorker
 {
     public virtual int AmountProduced(TitheInfo info) =>
-        Mathf.RoundToInt(info.Type.count * info.Speed.Mult() * (info.Lord?.Honors()
+        Mathf.Max(1, Mathf.RoundToInt(info.Type.count * info.Speed.Mult() * (info.Lord?.Honors()
            .Honors
            .OfType<Honor_Settlement>()
            .Where(h => h.settlement == info.Settlement)
-           .Aggregate(1f, (f, h) => f * h.def.titheSpeedFactor) ?? 1f));
+           .Aggregate(1f, (f, h) => f * h.def.titheSpeedFactor) ?? 1f)));
 
     protected virtual Thing MakeThing(TitheInfo info)
     {


### PR DESCRIPTION
This will fix an issue (or at least what I assume is one) by setting the minimum tithe amount to 1. Previously it was possible to "receive" 0 slaves as tithe from your vassal, so with this change it should no longer be possible.