### PR TITLE
Changes to handling of tithes

### DIFF
--- a/1.5/Source/VFEEmpire/VFEEmpire/Comps/WorldComponent_Vassals.cs
+++ b/1.5/Source/VFEEmpire/VFEEmpire/Comps/WorldComponent_Vassals.cs
@@ -46,7 +46,9 @@ public class WorldComponent_Vassals : WorldComponent
             {
                 info.Lord = null;
                 info.DaysSinceDelivery = 0;
-                if (info.Setting != TitheSetting.Special)
+                if (info.Setting.IsSpecial())
+                    info.Setting = TitheSetting.Special;
+                else
                     info.Setting = TitheSetting.Never;
             }
     }
@@ -69,11 +71,15 @@ public class WorldComponent_Vassals : WorldComponent
         {
             if (info.Lord == null) continue;
             info.DaysSinceDelivery++;
-            if (info.Setting == TitheSetting.Never) continue;
+            if (info.Setting.IsDisabled()) continue;
             if (info.DaysSinceDelivery >= info.Setting.DeliveryDays(info))
             {
-                info.Type.Worker.Deliver(info);
-                info.DaysSinceDelivery = 0;
+                // Only reset the days to 0 if successfully delivered.
+                // Setting it to 0 would reset stockpiles (since those
+                // are based on the days since last delivery), as well
+                // as reset the timer on delivery of special tithes.
+                if (info.Type.Worker.Deliver(info))
+                    info.DaysSinceDelivery = 0;
             }
         }
     }

--- a/1.5/Source/VFEEmpire/VFEEmpire/TitheTypeDef.cs
+++ b/1.5/Source/VFEEmpire/VFEEmpire/TitheTypeDef.cs
@@ -28,21 +28,36 @@ public class TitheTypeDef : Def
 
     public string ResourceLabel(int amount) => amount != 1 && !resourceLabelPlural.NullOrEmpty() ? resourceLabelPlural : resourceLabel;
     public string ResourceLabelCap(int amount) => ResourceLabel(amount).CapitalizeFirst();
+    // If range always plural, if plural label provided. If not a range then follow normal rules.
+    public string ResourceLabel(IntRange amount) => amount.min == amount.max ? ResourceLabel(amount.min) : ResourceLabel(2);
+    public string ResourceLabelCap(IntRange amount) => ResourceLabel(amount).CapitalizeFirst();
 }
 
 public class TitheWorker
 {
-    public virtual int AmountProduced(TitheInfo info) =>
-        Mathf.Max(1, Mathf.RoundToInt(info.Type.count * info.Speed.Mult() * (info.Lord?.Honors()
+    public virtual int AmountProduced(TitheInfo info) => GenMath.RoundRandom(AmountProducedBase(info));
+
+    public virtual float AmountProducedBase(TitheInfo info) =>
+        Mathf.Max(0f, info.Type.count * info.Speed.Mult() * (info.Lord?.Honors()
            .Honors
            .OfType<Honor_Settlement>()
            .Where(h => h.settlement == info.Settlement)
-           .Aggregate(1f, (f, h) => f * h.def.titheSpeedFactor) ?? 1f)));
+           .Aggregate(1f, (f, h) => f * h.def.titheSpeedFactor) ?? 1f));
+
+    public IntRange AmountProducedRange(TitheInfo info)
+    {
+        var amount = AmountProducedBase(info);
+        return new IntRange(Mathf.FloorToInt(amount), Mathf.CeilToInt(amount));
+    }
 
     protected virtual Thing MakeThing(TitheInfo info)
     {
+        var amount = AmountProduced(info);
+        if (amount <= 0)
+            return null;
+
         var thing = ThingMaker.MakeThing(info.Type.item);
-        thing.stackCount = AmountProduced(info);
+        thing.stackCount = amount;
         return thing;
     }
 
@@ -51,28 +66,73 @@ public class TitheWorker
         for (var i = 0; i < info.DaysSinceDelivery; i++) yield return MakeThing(info);
     }
 
-    public void Deliver(TitheInfo info)
+    public bool Deliver(TitheInfo info)
     {
         if (DeliverInt(info, out var desc, out var lookTargets))
-            Messages.Message("VFEE.TitheArrived".Translate(desc, info.Settlement.Name), lookTargets, MessageTypeDefOf.PositiveEvent);
+        {
+            if (!string.IsNullOrWhiteSpace(desc))
+                Messages.Message("VFEE.TitheArrived".Translate(desc, info.Settlement.Name), lookTargets, MessageTypeDefOf.PositiveEvent);
+            return true;
+        }
+
+        return false;
     }
 
     protected virtual bool DeliverInt(TitheInfo info, out string description, out LookTargets lookTargets)
     {
-        var things = CreateDeliveryThings(info).Consolidate();
+        var things = CreateDeliveryThings(info).Where(x => x != null).Consolidate();
+        // If we generated nothing, count that as success.
+        // It's possible for slave tithes to return nothing.
+        if (things.NullOrEmpty())
+        {
+            description = null;
+            lookTargets = null;
+            return true;
+        }
+
         description = Describe(things, info);
 
         if (info.Lord.GetCaravan() is { } caravan)
         {
+            // Calculate the mass of all everything that's not a pawn (pawn should walk themselves).
+            // If the weight is higher than the caravan's carry capacity, don't deliver.
+            var mass = things.Where(x => x is not Pawn).Sum(x => x.GetStatValue(StatDefOf.Mass) * x.stackCount);
+            if (mass > 0 && caravan.MassCapacity - caravan.MassUsage <= mass)
+            {
+                lookTargets = null;
+                return false;
+            }
+
             foreach (var thing in things)
-                CaravanInventoryUtility.GiveThing(caravan, thing);
+                caravan.AddPawnOrItem(thing, true);
             lookTargets = caravan;
             return true;
         }
 
-        if (info.Lord.MapHeld is { IsPlayerHome: true } map)
+        var map = info.Lord.MapHeld;
+        var currentMap = map;
+
+        // If the royal pawn is on a pocket map then attempt to drop to its parent map.
+        if (map is { IsPocketMap: true })
+            map = (map.Parent as PocketMapParent)?.sourceMap;
+
+        if (map is { IsPlayerHome: true })
         {
-            DropPodUtility.DropThingsNear(info.Lord.PositionHeld, map, things, canRoofPunch: false, forbid: false);
+            // Try to find a drop spot near the royal pawn, but only if not inside a pocket map.
+            // Otherwise, just pick a trade drop spot (if possible).
+            if (map != currentMap || !DropCellFinder.TryFindDropSpotNear(info.Lord.PositionHeld, map, out var position, false, false, false))
+            {
+                position = DropCellFinder.TradeDropSpot(map);
+
+                // If no valid position was found, skip delivery.
+                if (!position.IsValid)
+                {
+                    lookTargets = null;
+                    return false;
+                }
+            }
+
+            DropPodUtility.DropThingsNear(position, map, things, canRoofPunch: false, forbid: false);
             lookTargets = things;
             return true;
         }
@@ -103,5 +163,6 @@ public enum TitheSetting
     EveryQuadrum,
     EveryYear,
     Never,
-    Special
+    Special,
+    SpecialNever,
 }

--- a/1.5/Source/VFEEmpire/VFEEmpire/Utilities/VassalUtility.cs
+++ b/1.5/Source/VFEEmpire/VFEEmpire/Utilities/VassalUtility.cs
@@ -49,9 +49,13 @@ public static class VassalUtility
             TitheSetting.EveryQuadrum => 15,
             TitheSetting.EveryYear => 60,
             TitheSetting.Special => info?.Type?.deliveryDays ?? 0,
-            TitheSetting.Never => 0,
+            TitheSetting.Never or TitheSetting.SpecialNever => 0,
             _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, null)
         };
+
+    public static bool IsSpecial(this TitheSetting setting) => setting is TitheSetting.Special or TitheSetting.SpecialNever;
+
+    public static bool IsDisabled(this TitheSetting setting) => setting is TitheSetting.Never or TitheSetting.SpecialNever;
 
     public static TitheInfo Tithe(this Settlement settlement) => WorldComponent_Vassals.Instance.GetTitheInfo(settlement);
 }

--- a/Languages/English/Keyed/UI.xml
+++ b/Languages/English/Keyed/UI.xml
@@ -15,6 +15,7 @@
     <VFEE.Deliver.EveryWeek>Every 7 days</VFEE.Deliver.EveryWeek>
     <VFEE.Deliver.EveryQuadrum>Every 15 days</VFEE.Deliver.EveryQuadrum>
     <VFEE.Deliver.EveryYear>Once a year</VFEE.Deliver.EveryYear>
+    <VFEE.Deliver.DaysSpecific>Every {0} days</VFEE.Deliver.DaysSpecific>
     <VFEE.Deliver.Never>Never (pause)</VFEE.Deliver.Never>
     <VFEE.Created>{0} {1} created every day.</VFEE.Created>
     <VFEE.CreatedSpecial>{0} {1} created every {2} days.</VFEE.CreatedSpecial>


### PR DESCRIPTION
Skipping the long technical explanation behind every single change:
- Tithes that had fractional part will now be rounded up/down randomly
  - Chance is based on the fractional part - the higher it is, the more likely it is that the higher roll will happen (`GenMath.RoundRandom`)
- Special tithes can now be paused
  - However, they don't have a stockpile like the normal tithes do
  - The option is not present for (theoretical) tithes that take 0 days to deliver (if added by mods)
- If a delivery fails for whatever reason it will no longer reset stockpile and time until next delivery
  - Instead, delivery will happen on the next day
- If a royal pawn is on a pocket map, the delivery will instead be attempted to its parent map
- Tithes will fail to deliver to caravans if it'll put them over carry capacity
- Tithes will fail to deliver to maps with no valid places to deliver them to
- Fixed tithes breaking through the roof
- Fixed tithes to caravan if the tithe is pawns